### PR TITLE
Fix: Do not add affiliation for person

### DIFF
--- a/ckanext/doi/lib/helpers.py
+++ b/ckanext/doi/lib/helpers.py
@@ -84,10 +84,7 @@ def get_authors(creator_list):
         if entry.get('type') == 'person':
             last = entry.get('last_name', '')
             first = entry.get('first_name', '')
-            affiliation = entry.get('organisation', '')
             formatted = f"{last}, {first[:1]}." if last or first else ''
-            if affiliation:
-                formatted += f" ({affiliation})"
             if formatted:
                 authors.append(formatted)
         elif entry.get('type') == 'organisation':


### PR DESCRIPTION
This pull request includes a change to the `get_authors` function in `ckanext/doi/lib/helpers.py`. The change simplifies the formatting of authors by removing the inclusion of their affiliations.

Simplification of author formatting:

* [`ckanext/doi/lib/helpers.py`](diffhunk://#diff-ace5cdd701d7c80bf926994c229ea27c7492b487fb630888253fcf753351b3cbL87-L90): Removed the `affiliation` field from the author formatting logic, which previously appended the organization name in parentheses to the formatted author string.